### PR TITLE
Remove bare-metal runtime dependency

### DIFF
--- a/startup_stm32l476xx.s
+++ b/startup_stm32l476xx.s
@@ -95,8 +95,10 @@ LoopFillZerobss:
   cmp r2, r4
   bcc FillZerobss
 
-/* Call static constructors */
-    bl __libc_init_array
+/* Static constructors are normally called via __libc_init_array, which is
+   provided by the C runtime. This bare-metal project links with -nostdlib,
+   so the symbol is unavailable and calling it would cause a link error. */
+/* bl __libc_init_array */
 /* Call the application's entry point.*/
 	bl	main
 


### PR DESCRIPTION
## Summary
- avoid call to `__libc_init_array` in the startup file
  - linking without the C runtime caused an unresolved symbol

## Testing
- `make` *(fails: arm-none-eabi-gcc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afbb1b5748322b4e90a0825cb5e3a